### PR TITLE
Fixing readme example error

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ webdriverio
         .then(function(title) {
             console.log('Title was: ' + title);
         })
-        .reject(function(error) {
+        .catch(function(error) {
             console.log('uups something went wrong', error);
         })
     .end();


### PR DESCRIPTION
Example ion readme was giving

```
TypeError: Object #<WebdriverIO> has no method 'reject'
```
